### PR TITLE
Add .tih to list of supported file types

### DIFF
--- a/grammars/language-tiger.json
+++ b/grammars/language-tiger.json
@@ -5,7 +5,8 @@
 		"tg",
 		"tgr",
 		"tig",
-		"tiger"
+		"tiger",
+		"tih"
 	],
 	"patterns": [
 		{


### PR DESCRIPTION
This PR adds `.tih` files to the list of supported files.

We use .tih files at EPITA to have "header files" that are then included in the initialization of let...(here)...in...end statements. By default, this extension does not seem to support that (you'd have to manually associate .tih files to `tiger` with Ctrl+Shift+P -> Change Language Mode)